### PR TITLE
Update CMakeLists.txt to Use Flags Correctly with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ particle_stress_data.json
 /build/CMake/*
 !CMakeLists.txt
 !README.md
+!cmake-build-linux.bash
+!cmake-build-win.bat

--- a/build/CMake/CMakeLists.txt
+++ b/build/CMake/CMakeLists.txt
@@ -11,6 +11,9 @@ find_package(OpenMP REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Set the output directories for the compiled binaries
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}")
+
 # Flags
 set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -O0 -fopenmp")
 set(CMAKE_CXX_FLAGS_RELEASE "-Wall -Wextra -O3 -march=native -flto -ffast-math -funroll-loops -DNDEBUG -fopenmp")

--- a/build/CMake/CMakeLists.txt
+++ b/build/CMake/CMakeLists.txt
@@ -1,19 +1,23 @@
 # Specify the minimum required CMake version for this project
 cmake_minimum_required(VERSION 3.10)
 
-# Set the C++ standard to C++11
-set(CMAKE_CXX_STANDARD 11)
-
 # Project name
-project(MPM-GEOMECHANICS)
+project(MPM-GEOMECHANICS-PROJECT)
 
-# C++ standard settings
+# OpenMP Package
+find_package(OpenMP REQUIRED)
+
+# Set the C++ standard to C++17
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Flags configurations
+# Flags
 set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -O0 -fopenmp")
 set(CMAKE_CXX_FLAGS_RELEASE "-Wall -Wextra -O3 -march=native -flto -ffast-math -funroll-loops -DNDEBUG -fopenmp")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -O3 -march=native -flto -ffast-math -funroll-loops -DNDEBUG -fopenmp")
+
+# Set parallel level
+set(CMAKE_BUILD_PARALLEL_LEVEL 4)
 
 # Add include directory
 include_directories(../../inc)

--- a/build/CMake/CMakeLists.txt
+++ b/build/CMake/CMakeLists.txt
@@ -16,8 +16,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
 # Flags
 set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -O0 -fopenmp")
-set(CMAKE_CXX_FLAGS_RELEASE "-Wall -Wextra -O3 -march=native -flto -ffast-math -funroll-loops -DNDEBUG -fopenmp")
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -O3 -march=native -flto -ffast-math -funroll-loops -DNDEBUG -fopenmp")
+set(CMAKE_CXX_FLAGS_RELEASE "-Wall -Wextra -O3 -march=native -flto=auto -ffast-math -funroll-loops -DNDEBUG -fopenmp -std=c++17")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -O3 -march=native -ffast-math -funroll-loops -DNDEBUG -fopenmp -std=c++17")
 
 # Set parallel level
 set(CMAKE_BUILD_PARALLEL_LEVEL 4)

--- a/build/CMake/README.md
+++ b/build/CMake/README.md
@@ -17,7 +17,7 @@ The simplest way to compile on windows is by using the `.bat` file at `/build/CM
 
 ```
 cd build/CMake
-./cmake-build-win
+./cmake-build-win.bat
 ```
 
 Alternatively, you can use the following commands:
@@ -45,7 +45,7 @@ The simplest way to compile on Linux is by using the `.bash` file at `/build/CMa
 
 ```
 cd build/CMake
-./cmake-build-linux
+./cmake-build-linux.bash
 ```
 
 Alternatively, you can use the following commands:

--- a/build/CMake/README.md
+++ b/build/CMake/README.md
@@ -13,11 +13,19 @@
 
 #### 1.2. Compilation with Windows
 
+The simplest way to compile on windows is by using the `.bat` file at `/build/CMake`, just execute:
+
 ```
-cd build
-cd CMake
-cmake -G "MinGW Makefiles" .
-cmake --build .
+cd build/CMake
+./cmake-build-win
+```
+
+Alternatively, you can use the following commands:
+
+```
+cd build/CMake
+cmake -G "MinGW Makefiles" -B build
+cmake --build build
 ```
 
 ### 2. Linux
@@ -33,9 +41,17 @@ cmake --build .
 
 #### 1.2. Compilation with Linux
 
+The simplest way to compile on Linux is by using the `.bash` file at `/build/CMake`, just execute:
+
 ```
-cd build
-cd CMake
-cmake -G "Unix Makefiles" .
-cmake --build .
+cd build/CMake
+./cmake-build-linux
+```
+
+Alternatively, you can use the following commands:
+
+```
+cd build/CMake
+cmake -G "Unix Makefiles" -B build
+cmake --build build
 ```

--- a/build/CMake/cmake-build-linux.bash
+++ b/build/CMake/cmake-build-linux.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Run cmake to generate build files
+cmake -G "Unix Makefiles" -B build
+if [ $? -ne 0 ]; then
+  echo "Error: CMake generation failed."
+  exit 1
+fi
+
+# Build the project
+cmake --build build
+if [ $? -ne 0 ]; then
+  echo "Error: Project build failed."
+  exit 1
+fi
+
+echo "Project successfully built."

--- a/build/CMake/cmake-build-win.bat
+++ b/build/CMake/cmake-build-win.bat
@@ -1,0 +1,17 @@
+@echo off
+
+REM Runs CMake to generate build files with MinGW Makefiles
+cmake -G "MinGW Makefiles" -B build
+IF %ERRORLEVEL% NEQ 0 (
+  echo Error: CMake generation failed.
+  exit /b %ERRORLEVEL%
+)
+
+REM Builds the project from the build folder
+cmake --build build
+IF %ERRORLEVEL% NEQ 0 (
+  echo Error: Project build failed.
+  exit /b %ERRORLEVEL%
+)
+
+echo Project built successfully.


### PR DESCRIPTION
### Add
- Add scripts  (at `/build/CMake`) for Windows and Linux to compile with **CMake** in a simple way.

### Changes
- Update CMakeLists.txt to include **optimization flags** correctly
- Update CMakeLists.txt to use **OpenMP** correctly