### PR TITLE
Velocity approach for seismic without stl contact

### DIFF
--- a/inc/MPM.h
+++ b/inc/MPM.h
@@ -132,10 +132,7 @@ private:
 	void setThreads();
 
 	/// \brief Get seismic analysis active
-	bool getSeismicAnalysis();
-
-	/// \brief Set seismic analysis active
-	void setSeismicAnalysis(bool);
+	bool getSeismicAnalysisActive();
 
 	/// \brief Configure one direction hydro-mechanical coupling
 	void setOneDirectionHydromechanicalCoupling();

--- a/inc/Model.h
+++ b/inc/Model.h
@@ -204,11 +204,11 @@ namespace ModelSetup {
 	
 	/// \brief Return true if seismic analysis is active
 	/// \return if_seismic_analysis_active
-	bool getSeismicAnalysis();
+	bool getSeismicAnalysisActive();
 
 	/// \brief Configure if seismic analysis is active
 	/// \param[in] seismic_analysis_active 
-	void setSeismicAnalysis(bool seismic_analysis_active);
+	void setSeismicAnalysisActive(bool seismic_analysis_active);
 
 	/// \brief Return if two-phase calculation is active
 	/// \return True if two-phase calculation is active

--- a/inc/Seismic.h
+++ b/inc/Seismic.h
@@ -86,13 +86,13 @@ namespace Seismic
     void applySeismicVelocityMarkedSTLNodes(double currentTime, double dt, Mesh* mesh);
     
     /**
-     * @brief Updates the accumulated seismic velocity based on the current time and time step.
+     * @brief Updates the accumulated seismic velocity and acceleration based on the current time and time step.
      * 
      * @param currentTime Current simulation time (s).
      * @param dt Simulation time step (s).
      * @note This function updates the global `accumulatedVelocity` variable with the seismic velocity
      */
-    void updateAccumulatedSeismicVelocity(const double currentTime, const double dt);
+    void updateSeismicVectors(const double currentTime, const double dt);
 
     /**
      * @brief Marks the nodes that will receive seismic loading.
@@ -118,7 +118,13 @@ namespace Seismic
      * @brief Returns the accumulated seismic velocity.
      * @return Eigen::Vector3d& Reference to the accumulated velocity vector.
      */
-    Eigen::Vector3d& getAccumulatedVelocity();
+    const Eigen::Vector3d& getAccumulatedVelocity();
+
+    /**
+     * @brief Returns the seismic acceleration.
+     * @return Eigen::Vector3d& Reference to the seismic acceleration vector.
+     */
+    const Eigen::Vector3d& getAcceleration();
 
     /**
      * @brief Disables seismic analysis.

--- a/inc/Seismic.h
+++ b/inc/Seismic.h
@@ -77,14 +77,23 @@ namespace Seismic
     void setSeismicAnalysis(const SeismicAnalysis& info);
     
     /**
-     * @brief Applies seismic velocity to the marked seismic nodes.
+     * @brief Applies seismic velocity to the marked seismic nodes using STL mesh.
      *
      * @param currentTime Current simulation time (s).
      * @param dt Simulation time step (s).
      * @param mesh Pointer to the Eulerian background mesh.
      */
-    void applySeismicVelocity(double currentTime, double dt, Mesh* mesh);
+    void applySeismicVelocityMarkedSTLNodes(double currentTime, double dt, Mesh* mesh);
     
+    /**
+     * @brief Updates the accumulated seismic velocity based on the current time and time step.
+     * 
+     * @param currentTime Current simulation time (s).
+     * @param dt Simulation time step (s).
+     * @note This function updates the global `accumulatedVelocity` variable with the seismic velocity
+     */
+    void updateAccumulatedSeismicVelocity(const double currentTime, const double dt);
+
     /**
      * @brief Marks the nodes that will receive seismic loading.
      * @param epsilon Grid dimension factor threshold to mark nodes as seismic nodes.

--- a/src/MPM.cpp
+++ b/src/MPM.cpp
@@ -146,7 +146,7 @@ void MPM::setupMesh() {
 	// configure the mesh boundary conditions
 	mesh.setBoundaryRestrictions(Input::getMeshBoundaryConditions());
 
-	if(ModelSetup::getSeismicAnalysis()){
+	if(ModelSetup::getSeismicAnalysisActive()){
 		// set the boundary conditions for seismic analysis
 		mesh.setBoundaryRestrictionsSeismic();
 	}
@@ -195,7 +195,7 @@ void MPM::setupTerrainContact()
 		terrainContact->computeDistanceLevelSetFunction(&mesh);
 
 		// mark seismic nodes for STL seismic loading
-		if (ModelSetup::getSeismicAnalysis() && terrainContact != nullptr)
+		if (ModelSetup::getSeismicAnalysisActive() && terrainContact != nullptr)
 		{
 	    	double epsilon = 0.25 * mesh.getCellDimension().mean();
     		
@@ -319,7 +319,7 @@ void MPM::setupSeismicAnalysis() {
 	// configure seismic analysis in mpm model
 	if(!Seismic::getSeismicAnalysis().isActive) return;
 	
-	ModelSetup::setSeismicAnalysis(true);
+	ModelSetup::setSeismicAnalysisActive(true);
 
 	// setup seismic data
 	Seismic::setSeismicData();

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -199,8 +199,8 @@ namespace ModelSetup {
 	}
 
 	// Seismic analysis
-	bool getSeismicAnalysis() {return seismicAnalysisActive;}
-	void setSeismicAnalysis(bool a) {seismicAnalysisActive = a;}
+	bool getSeismicAnalysisActive() {return seismicAnalysisActive;}
+	void setSeismicAnalysisActive(bool a) {seismicAnalysisActive = a;}
 
 	// hydro-mechanical coupling
 

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -461,7 +461,7 @@ namespace Output{
 		gridFile<<"</DataArray>\n";
 
 		// print seismic nodes
-		if (ModelSetup::getTerrainContactActive() && ModelSetup::getSeismicAnalysis()) {
+		if (ModelSetup::getTerrainContactActive() && ModelSetup::getSeismicAnalysisActive()) {
 			// export seismic nodes
 			gridFile << "<DataArray type=\"UInt8\" Name=\"Seismic Node\" Format=\"ascii\">\n";
 			for (int i = 0; i < nPoints; ++i) {

--- a/src/Seismic.cpp
+++ b/src/Seismic.cpp
@@ -12,6 +12,7 @@ namespace Seismic
     std::vector<int> seismicNodeIndices;
     std::unordered_set<int> seismicNodeSet;
     Eigen::Vector3d accumulatedVelocity = Eigen::Vector3d::Zero();
+    Eigen::Vector3d seismicAcceleration = Eigen::Vector3d::Zero();
 
     // Seismic file information
     SeismicAnalysis seismic_analysis;
@@ -23,7 +24,10 @@ namespace Seismic
     SeismicAnalysis& getSeismicAnalysis() { return seismic_analysis; }
 
     // Get accumulated velocity
-    Eigen::Vector3d& getAccumulatedVelocity() { return accumulatedVelocity; }
+    const Eigen::Vector3d& getAccumulatedVelocity() { return accumulatedVelocity; }
+
+    // Get seismic acceleration
+    const Eigen::Vector3d& getAcceleration() { return seismicAcceleration; }
 
     // Set seismic analysis information
     void setSeismicAnalysis(const SeismicAnalysis& info) { seismic_analysis = info; }
@@ -81,7 +85,9 @@ namespace Seismic
     // check if a node is a seismic node
     bool isSeismicNode(int nodeId) { return seismicNodeSet.count(nodeId) > 0; }
 
-    void updateAccumulatedSeismicVelocity(const double currentTime, const double dt) {
+    // Update seismic vectors based on current time and time step
+    // This function integrates the seismic acceleration to update the accumulated velocity
+    void updateSeismicVectors(const double currentTime, const double dt) {
 
         // Interpolate seismic acceleration at the current time
         Eigen::Vector3d a_sismo = Interpolation::interpolateVector(
@@ -90,8 +96,9 @@ namespace Seismic
             currentTime
         );
 
-        // Integrate to get the accumulated velocity
-        accumulatedVelocity += a_sismo * dt;
+        // Update seismic acceleration and accumulated velocity
+        accumulatedVelocity += a_sismo * dt; // integrate acceleration to get velocity
+        seismicAcceleration = a_sismo; // Update the seismic acceleration
     }
 
     void applySeismicVelocityMarkedSTLNodes(double currentTime, double dt, Mesh* mesh)

--- a/src/SolverExplicit.cpp
+++ b/src/SolverExplicit.cpp
@@ -43,7 +43,7 @@ void SolverExplicit::Solve()
 		}
 
 		if(isSeismicAnalysis){
-			Seismic::updateAccumulatedSeismicVelocity(iTime, loopCounter == 1 ? dt / 2.0 : dt);
+			Seismic::updateSeismicVectors(iTime, loopCounter == 1 ? dt / 2.0 : dt);
 		}
 
 		// Step 2: Apply boundary conditions on nodal momentum

--- a/src/SolverExplicit.cpp
+++ b/src/SolverExplicit.cpp
@@ -15,7 +15,7 @@ SolverExplicit::SolverExplicit() : Solver() {}
 
 void SolverExplicit::Solve()
 {
-	// Initialize simulation variables
+	// Initialization of simulation variables
 	double time = ModelSetup::getTime();
 	double dt = ModelSetup::getTimeStep();
 	int resultSteps = ModelSetup::getResultSteps();
@@ -25,13 +25,13 @@ void SolverExplicit::Solve()
 	bool useSTLContact = ModelSetup::getTerrainContactActive();
 	bool isSeismicAnalysis = ModelSetup::getSeismicAnalysisActive();
 
-	// Solve in time
+	// Time integration loop
 	while (iTime < time)
 	{
-		// Output results
+		// Write output results
 		Output::writeResultInStep(loopCounter++, resultSteps, bodies, iTime);
 
-		// Step 1: Interpolate mass and momentum from Particles to Nodes
+		// Step 1: Particle-to-Grid mass and momentum interpolation
 		Update::contributionNodes(mesh, bodies);
 		#pragma omp parallel sections num_threads(2)
 		{
@@ -42,15 +42,16 @@ void SolverExplicit::Solve()
 			Interpolation::nodalMomentum(mesh, bodies);
 		}
 
-		// Update seismic velocity and acceleration from record if seismic analysis is active
+		// Update seismic velocity and acceleration from record
 		if(isSeismicAnalysis){
 			Seismic::updateSeismicVectors(iTime, loopCounter == 1 ? dt / 2.0 : dt);
 		}
 
-		// Step 2: Apply boundary conditions on nodal momentum
+		// Step 2: Impose boundary conditions on nodal momentum
 		Update::boundaryConditionsMomentum(mesh);
 
-		// Step 3.1: Interpolate internal and external force from particles to nodes
+		// Step 3: Compute nodal forces
+		// 3.1: Internal and external nodal force
 		#pragma omp parallel sections num_threads(2)
 		{
 			#pragma omp section
@@ -60,39 +61,40 @@ void SolverExplicit::Solve()
 			Interpolation::nodalExternalForce(mesh, bodies);
 		}
 
-		// Step 3.2: Compute total nodal force
+		// 3.2: Total force nodal force
 		Update::nodalTotalForce(mesh);
 
-		// Step 3.3: Apply boundary conditions on total force
+		// 3.3: Impose boundary conditions on total force
 		Update::boundaryConditionsForce(mesh);
 
 		// Step 4: Integrate nodal momentum
 		Integration::nodalMomentum(mesh, loopCounter == 1 ? dt / 2.0 : dt);
 
-		// Step 5.1: Update particle velocity
+		// Step 5: Particle updates
+		// 5.1: Update particle velocity
 		Update::particleVelocity(mesh, bodies, loopCounter == 1 ? dt / 2.0 : dt);
 
-		// Step 5.2: Apply contact correction in particle velocity
+		// 5.2: Apply contact correction in particle velocity
 		if (useSTLContact){
 
-			// Step 5.2.1: Apply seismic velocity to marked nodes
+			// 5.2.1: Apply seismic velocity to marked nodes
 			if (isSeismicAnalysis){
 				Seismic::applySeismicVelocityMarkedSTLNodes(iTime, dt, mesh);
 			}
 			terrainContact->apply(mesh, particles, dt);
 		}
 
-		// Step 5.3: Update particle position
+		// 5.3: Update particle position
 		Update::particlePosition(mesh, bodies, dt);
 
-		// Step 6 (MUSL only): Recalculate nodal momentum and apply BCs on nodal momentum 
+		// Step 6 (MUSL): Momentum recalculation 
 		if (useMUSL)
 		{	
-			// Step 6.1 (MUSL only): Recalculate nodal momentum with updated particle velocity
+			// 6.1: Recalculate nodal momentum
 			Update::resetNodalMomentum(mesh);
 			Interpolation::nodalMomentum(mesh, bodies);
 			
-			// Step 6.2 (MUSL only): Reapply BCs on nodal momentum
+			// 6.2: Reapply BCs on nodal momentum
 			Update::boundaryConditionsMomentum(mesh);
 		}
 
@@ -116,14 +118,14 @@ void SolverExplicit::Solve()
 		// Step 10: Reset nodal values
 		Update::resetNodalValues(mesh);
 
-		// Check for static solution
+		// Static solution check (Dynamic Relaxation)
 		DynamicRelaxation::setStaticSolution(bodies, loopCounter);
 
-		// Step 11: Advance time
+		// Step 11: Advance simulation time
 		ModelSetup::setCurrentTime(iTime += dt);
 	}
 
-	// Write results
+	// Final output
 	Output::writeGrid(mesh, Output::CELLS);
 	Output::writeResultsSeries();
 }

--- a/src/SolverExplicit.cpp
+++ b/src/SolverExplicit.cpp
@@ -23,7 +23,7 @@ void SolverExplicit::Solve()
 	int loopCounter = 0;
 	bool useMUSL = (ModelSetup::getUpdateStressScheme() == ModelSetup::MUSL);
 	bool useSTLContact = ModelSetup::getTerrainContactActive();
-	bool isSeismicAnalysis = ModelSetup::getSeismicAnalysis();
+	bool isSeismicAnalysis = ModelSetup::getSeismicAnalysisActive();
 
 	// Solve in time
 	while (iTime < time)
@@ -42,12 +42,16 @@ void SolverExplicit::Solve()
 			Interpolation::nodalMomentum(mesh, bodies);
 		}
 
+		if(isSeismicAnalysis){
+			Seismic::updateAccumulatedSeismicVelocity(iTime, loopCounter == 1 ? dt / 2.0 : dt);
+		}
+
 		// Step 2: Apply boundary conditions on nodal momentum
 		Update::boundaryConditionsMomentum(mesh);
 
 		// Step 2.1: Apply seismic velocity to marked nodes
 		if (isSeismicAnalysis && useSTLContact){
-			Seismic::applySeismicVelocity(iTime, dt, mesh);
+			Seismic::applySeismicVelocityMarkedSTLNodes(iTime, dt, mesh);
 		}
 
 		// Step 3.1: Interpolate internal and external force from particles to nodes

--- a/src/TerrainContact.cpp
+++ b/src/TerrainContact.cpp
@@ -328,7 +328,7 @@ void TerrainContact::computeContactForces(std::vector< Particle* >* particles, d
     (void)particles;
 
     // check if seismic analysis is enabled
-    bool isSeismic = ModelSetup::getSeismicAnalysis();
+    bool isSeismic = ModelSetup::getSeismicAnalysisActive();
 
     // get the accumulated velocity from seismic analysis
     Vector3d v_surface = isSeismic ? Seismic::getAccumulatedVelocity() : Vector3d::Zero(); 

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -467,13 +467,13 @@ void Update::boundaryConditionsMomentumFluid(Mesh* mesh) {
 	setPlaneMomentumFluid(mesh->getBoundary()->getPlaneZn(), nodes, Update::Direction::Z);
 }
 
-void Update::boundaryConditionsMomentum(Mesh* mesh) {
-
+void Update::boundaryConditionsMomentum(Mesh* mesh) 
+{
 	// Verify if seismic was disabled during the simulation.
 	// This can happen if the simulation time is greater than the seismic data time.
 	if (!ModelSetup::getSeismicAnalysisActive() && mesh->getBoundary()->getPlaneZ0()->restriction == Boundary::BoundaryType::EARTHQUAKE) {
-		// change EARTHQUAKE to SLIDING
-		mesh->getBoundary()->setRestrictions(Boundary::BoundaryPlane::Z0, Boundary::BoundaryType::SLIDING);
+		// change EARTHQUAKE to FIXED for the mesh boundary
+		mesh->getBoundary()->setRestrictions(Boundary::BoundaryType::FIXED);
 	}
 
 	// get nodes
@@ -491,8 +491,10 @@ void Update::boundaryConditionsMomentum(Mesh* mesh) {
 
 } 
 
-void Update::setPlaneForce( const Boundary::planeBoundary* plane, vector<Node*>* nodes, unsigned dir) {
-
+/// @brief Set force boundary conditions in the specified plane
+/// @details This function applies boundary conditions to the nodal forces based on the specified plane
+void Update::setPlaneForce( const Boundary::planeBoundary* plane, vector<Node*>* nodes, unsigned dir) 
+{
 	// get boundary nodes
 	#pragma omp parallel for shared(plane, nodes, dir)
 	for (int i = 0; i < static_cast<int>(plane->nodes.size()); ++i) {
@@ -500,17 +502,17 @@ void Update::setPlaneForce( const Boundary::planeBoundary* plane, vector<Node*>*
 		// get node handle 
 		Node* nodeI = nodes->at(plane->nodes.at(i));
 
+		// check if the node is active
+		// and apply the boundary condition based on the restriction type
 		if (nodeI->getActive()) {
 			
 			// witch type of restriction
 			switch(plane->restriction)
 			{
 				// free condition
-				case Boundary::BoundaryType::FREE:
-				{
-					break;
-				}
-				// fixed condition
+				case Boundary::BoundaryType::FREE: { break; }
+				
+				// fixed condition f_iI = 0
 				case Boundary::BoundaryType::FIXED:
 				{
 					// set all force component as zero 
@@ -566,13 +568,14 @@ void Update::setPlaneForce( const Boundary::planeBoundary* plane, vector<Node*>*
 	}
 }
 
-void Update::boundaryConditionsForce(Mesh* mesh) {
-	
+/// @brief Set force boundary conditions
+/// @param mesh Pointer to the mesh object 
+void Update::boundaryConditionsForce(Mesh* mesh)
+{	
 	// get nodes
 	vector<Node*>* nodes = mesh->getNodes();
 
 	// set f = 0 in fixed direction
-
 	setPlaneForce(mesh->getBoundary()->getPlaneX0(), nodes, Update::Direction::X);
 	setPlaneForce(mesh->getBoundary()->getPlaneY0(), nodes, Update::Direction::Y);
 	setPlaneForce(mesh->getBoundary()->getPlaneZ0(), nodes, Update::Direction::Z);

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -557,8 +557,7 @@ void Update::setPlaneForce( const Boundary::planeBoundary* plane, vector<Node*>*
 				// The force is set to zero in order to do not modify the nodal momentum
 				// during the seismic analysis. The seismic force is applied in the nodal momentum BCs.
 				// p_iI^{k+1/2} = p_iI^{k-1/2} + f_iI^{k}*dt
-				// if f_iI^{k} = 0, then p_iI^{k+1/2} = p_iI^{k-1/2}
-				// p_iI^{k-1/2} = p_iI^{Seismic}
+				// if f_iI^{k} = 0, then p_iI^{k+1/2} = p_iI^{k-1/2} = p_iI^{Seismic}
 				case Boundary::BoundaryType::EARTHQUAKE:
 				{ 
 					nodeI->setTotalForce(Eigen::Vector3d::Zero());

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -328,8 +328,10 @@ void Update::setPlaneMomentum(const Boundary::planeBoundary* plane, vector<Node*
 				case Boundary::BoundaryType::EARTHQUAKE:
 				{ 	
 					// set the seismic momentum
-                	nodeI->setMomentum(nodeI->getMass()*Seismic::getAccumulatedVelocity());
-					break; 
+					if(ModelSetup::getUpdateStressScheme() == ModelSetup::StressUpdateScheme::MUSL) {
+                		nodeI->setMomentum(nodeI->getMass()*Seismic::getAccumulatedVelocity());
+					}
+					break;
 				}
 
 				// fixed condition
@@ -553,14 +555,10 @@ void Update::setPlaneForce( const Boundary::planeBoundary* plane, vector<Node*>*
 					nodeI->setTotalForce(force);
 					break;
 				}
-				// Earthquake boundary condition
-				// The force is set to zero in order to do not modify the nodal momentum
-				// during the seismic analysis. The seismic force is applied in the nodal momentum BCs.
-				// p_iI^{k+1/2} = p_iI^{k-1/2} + f_iI^{k}*dt
-				// if f_iI^{k} = 0, then p_iI^{k+1/2} = p_iI^{k-1/2} = p_iI^{Seismic}
+				// Earthquake boundary condition in term of force
 				case Boundary::BoundaryType::EARTHQUAKE:
 				{ 
-					nodeI->setTotalForce(Eigen::Vector3d::Zero());
+					nodeI->setTotalForce(Seismic::getAcceleration()*nodeI->getMass());
 					break;
 				}
 			}

--- a/tests/vibrational-base-example/vibrational-base.json
+++ b/tests/vibrational-base-example/vibrational-base.json
@@ -1,15 +1,14 @@
 {
   "time":2,
   "critical_time_step_multiplier":0.3,
-  "stress_scheme_update":"USL",
+  "stress_scheme_update":"MUSL",
   "results":
   {
     "print":40,
     "fields":["displacement","velocity"]
   },
   "body":
-  {
-    "elastic-cuboid-body":
+  [
     {
       "type":"cuboid",
       "id":1,
@@ -17,12 +16,13 @@
       "point_p2":[0.7,0.7,0.8],
       "material_id":1
     }
-  },
+  ],
 	"materials":
-  [{
+  [
+    {
       "type":"elastic",
       "id":1,
-      "young":100e6,
+      "young":50e6,
       "density":2500,
       "poisson":0.25
     }
@@ -36,7 +36,7 @@
   "earthquake": 
   {
     "active":true,
-    "file": "base_acceleration.csv",
+    "file":"base_acceleration.csv",
     "header":true
   }
 }


### PR DESCRIPTION
The main contribution of this branch is to avoid numerical instabilities when MULS scheme was active together with the seismic load (See #45).

This was solved by adding seismic momentum boundary condition for MULS after momentum recalculation, and before nodal velocity calculation. 

The implementation was verified using the vibrational base example (see `\tests\vibrational-base-example`) and the seismic load example (see `\tests\seismic-load-stl-mesh`). In the verification the models were tested using USL and MULS scheme. 

<img width="1783" height="1133" alt="image" src="https://github.com/user-attachments/assets/53ac07e4-9368-49ef-ac6f-34e11f69b625" />

Adicionaly, in this implementation:
- were enhanced the names of the method to manage the seismic analysis,
- was added the acceleration to the seismic namespace in order to allow quick access, 
- was adding a method to updating the velocity and acceleration in each time step,
- was commented the main loop of the solver.