### PR TITLE
Undamped damping

### DIFF
--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -765,7 +765,7 @@ vector<Body*> Input::getBodyList(const vector<Material*>* materials){
 						Vector3d pos(p["position"][0], p["position"][1], p["position"][2]);
 						double vol = p["volume"];
 
-						unsigned material_id = 0.0;
+						unsigned material_id = 0;
 						if(homogeneous_flag)
 							material_id = mat_id_homogeneous;
 						else
@@ -1252,6 +1252,10 @@ ModelSetup::DampingType Input::getDampingType() {
 			return ModelSetup::DampingType::KINETIC_DYNAMIC_RELAXATION;
 		}
 
+		if(inputFile["damping"]["type"]=="none"){
+			return ModelSetup::DampingType::UNDAMPED;
+		}
+
 		throw(0);
 	}
 	catch(...)
@@ -1266,7 +1270,6 @@ double Input::getDampingValue() {
 	try
 	{
 		if (inputFile["damping"].is_null()){
-
 			return 0.0;
 		}
 
@@ -1282,8 +1285,9 @@ double Input::getDampingValue() {
 			{
 				return inputFile["damping"]["alpha"];
 			}
-
-			throw (0);
+				
+			std::cout<<"   Warning : Assuming alpha=0 (undaped)\n";
+			return 0.0;
 		}
 
 		throw (0);

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -956,8 +956,10 @@ namespace Output{
 			std::cout << "   Damping : Local (" << ModelSetup::getDampingLocal() << ")" << std::endl;
 		else if (ModelSetup::getDampingType() == ModelSetup::DampingType::KINETIC_DYNAMIC_RELAXATION)
 			std::cout << "   Damping : Kinetic" << std::endl;
-
-		if (ModelSetup::getSaveState()) {
+		else if (ModelSetup::getDampingType() == ModelSetup::DampingType::UNDAMPED)
+			std::cout << "   Damping : Undamped" << std::endl;
+		
+			if (ModelSetup::getSaveState()) {
 			std::cout << "Save state : Enabled" << std::endl;
 		}
 		if (ModelSetup::getLoadState()) {

--- a/tests/damping/slope/slope-failure.json
+++ b/tests/damping/slope/slope-failure.json
@@ -1,0 +1,71 @@
+{
+	"stress_scheme_update":"USL",
+	"time":1,
+	"time_step":0.001,
+	"gravity":[0.0,0.0,-9.81],
+	"n_threads":10,
+	"damping":
+	{
+		"type":"local",
+		"alpha":0.1
+	},
+
+   "results":
+	{
+		"print":10,
+		"material_point_results":["all"]
+	},
+
+	"mesh":
+	{	
+		"cells_dimension":[1,1,1],
+		"cells_number":[110,1,36],
+		"origin":[0,0,0],
+		
+		"boundary_conditions":
+		{
+			"plane_X0":"fixed",
+			"plane_Y0":"sliding",
+			"plane_Z0":"fixed",
+			"plane_Xn":"fixed",
+			"plane_Yn":"sliding",
+			"plane_Zn":"fixed"
+		}
+	},
+
+	"material":
+	{
+		"plastic":
+		{
+			"type":"mohr-coulomb",
+			"id":1,
+			"young":70e6,
+			"density":2100,
+			"poisson":0.3,
+			"friction":20.0,
+			"cohesion":1.0e3
+		}
+	},
+
+	"body":
+	{
+		"soil":
+		{
+			"type":"polygon_2d",
+			"extrude_direction":"y",
+			"extrude_displacement":1,
+			"discretization_length":1,
+			"id":1,
+			"points":
+			[
+				[  0, 0, 0 ],
+				[110, 0, 0 ],
+				[110, 0, 15],
+				[ 50, 0, 15],
+				[ 30, 0, 35],
+				[  0, 0, 35]
+			],
+			"material_id":1
+		}
+	}
+}


### PR DESCRIPTION
- removing compilation warnings during material id reader.
- adding an example of a slope verifying none damping implementation.
- adding undamped information in terminal.
- adding a warning when there is any damping type definition.  